### PR TITLE
Feature/001 create docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,9 @@ services:
       - DB_DATABASE=${DB_NSME:-laravel_local}
       - DB_USERNAME=${DB_USER:-soregashi27}
       - DB_PASSWORD=${DB_PASS:-soregashidegozaru}
+      # - DB_DATABASE=${DB_NAME}
+      # - DB_USERNAME=${DB_USER}
+      # - DB_PASSWORD=${DB_PASS}
 
   web:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,3 +41,21 @@ services:
       - DB_DATABASE=${DB_NSME:-laravel_local}
       - DB_USERNAME=${DB_USER:-soregashi27}
       - DB_PASSWORD=${DB_PASS:-soregashidegozaru}
+
+  web:
+    build:
+      context: .
+      dockerfile: ./infra/docker/nginx/Dockerfile
+    ports:
+      - target: 80
+        published: ${ WEB_PORT:-80}
+        protocol: tcp
+        mode: host
+    volumes:
+      - type: bind
+        source: php-fpm-socket
+        target: /vat/run/php-fpm
+        volume:
+          nocopy: true
+      - type: bind
+        source: ./vackend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,3 +59,26 @@ services:
           nocopy: true
       - type: bind
         source: ./vackend
+
+  db:
+    build:
+      context: .
+      dockerfile: ./infra/docker/mysql/Dockerfile
+    ports:
+      - target: 3306
+        published: ${DB_PORT:-3306}
+        protocol: tcp
+        mode: host
+    volumes:
+      - type: volume
+        source: db-store
+        target: /var/lib/mysql
+        volume:
+          nocopy: true
+    environment:
+      - MYSQL_DATABASE=${DB_NAME:-laravel_local}
+      - MYSQL_USER=${DB_USER:-soregashi27}
+      - MYSQL_PASSWORD=${DB_PASS:-soregashidegozaru}
+      - MYSQL_ROOT_PASSWORD=${DB_PASS:-soregashidegozaru}
+# TODO: root userで起動しないようにする設定を追加する
+# TODO: 他のファイルを作る前にAWS内のinstanceを削除する

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,5 +29,15 @@ services:
       - type: bind
         source: ./backend
         target: /work/backend
+      - type: volume
+        source: psysh-store
+        target: /root/.config/psysh
+        volume:
+          nocopy: true
     environment:
-      -
+      - DB_CONNECTION=mysql
+      - DB_HOST=db
+      - DB_PORT=3306
+      - DB_DATABASE=${DB_NSME:-laravel_local}
+      - DB_USERNAME=${DB_USER:-soregashi27}
+      - DB_PASSWORD=${DB_PASS:-soregashidegozaru}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,20 @@ version: '3.9'
 volumes:
   php-fpm-socket:
   db-store:
+  psysh-store:
+  pma-session-store:
 services:
-  # phpmyadminを追加する
+  pma:
+    image: phpmyadmin/phpmyadmin
+    environment:
+      - PMA_HOST=db
+      - PMA_USER=soregashi27
+      - PMA_PASSWORD=soregashidegozaru
+    ports:
+      - 8080:80
+    volumes:
+      - pma-session-store:/sessions
+
   app:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
         volume:
           nocopy: true
       - type: bind
-        source: ./vackend
+        source: ./backend
 
   db:
     build:


### PR DESCRIPTION
## 変更の概要
* 変更の概要
* 関連するIssueやプルリクエスト

## やりたいこと
* docker-compose.ymlの作成

## やったこと
* docker-compose.ymlの作成


## 悩んだこと
* 特になし

## 実装の詳細
app, web, dbの3つのコンテナを定義

### Docker composeのバージョン指定
```
version: '3.9'
```
Docker composeのバージョンを指定している

### ボリューム
```
volumes:
  php-fpm-socket:
  db-store:
  psysh-store:
  pma-session-store:
```
名前付きボリュームを定義。
ボリュームはコンテナ特定のdirectoryをhostのdirectoryにマウントする機能を提供する。
コンテナの再起動時に同じDirectoryにmount（使える状態にする）することでデータを永続化できる。
（DBのデータが毎回消えるということがなくなる）

unixソケット（php-fpm-socket）のボリュームはappコンテナとwebコンテナで共用で使いたいのでmount。
db-storeはコンテナを破棄してもデータが残るようにボリュームとして定義。

psysh-store
`php artisan`コマンドが使えるように設定。ターミナル環境でphpが使える。

pma-session-storeはphpmyadminでデータを可視化する時にデータをmountしているのでphpmyadminにもデータはmount
している状態にするために設定


### サービス
```
services:
```
アプリケーションを動かす時の各要素のことを指す。

#### pmaコンテナ
```
  pma:
    image: phpmyadmin/phpmyadmin
    environment:
      - PMA_HOST=db
      - PMA_USER=soregashi27
      - PMA_PASSWORD=soregashidegozaru
    ports:
      - 8080:80
    volumes:
      - pma-session-store:/sessions
```
phpmyadminのDocker Imageを使う

environmentは文字の如く環境変数
PMA_HOSTはphpmyadminのホストを指している。今回はdbとサービス名を指定している。

#### appコンテナ
```
  app:
    build:
      context: .
      dockerfile: ./infra/docker/php/Dockerfile
```
appコンテナはアプリケーションサーバーコンテナを定義している。phpを実行する。
buildでcontextとdockerfileを指定する。

contextというのは、`docker build`コマンドを実行する場所。
このコマンドはdockerfileがあるディレクトリで実行すれば問題ないがdocker composeだとそうもいかないので、
contextをroot directoryにする。`build`で`context`と`dockerfile`の場所を指定する

こうすることで`dockerfile`はどんなファイルにもアクセスできるようになる。（らしい）
とりあえず、contextとdockerfileを埋めとけって話。

```
    volumes:
      - type: volumes
        source: php-fpm-socket
        target: /var/run/php-fpm
        volume:
          nocopy: true
      - type: bind
        source: ./backend
        target: /work/backend
      - type: volume
        source: psysh-store
        target: /root/.config/psysh
        volume:
          nocopy: true
```
名前付きボリュームを定義。
ボリュームはコンテナ特定のdirectoryをhostのdirectoryにマウントする機能を提供する。
コンテナの再起動時に同じDirectoryにmount（使える状態にする）することでデータを永続化できる。

type：マウントタイプ（volume, bind, tmpfs, npipeと色々ある）
bind：ホスト側のディレクトリやファイルをコンテナ内にマウントすること。
バインドマウントによってコンテナで扱うデータを永続化できる。
source : マウント元
target：マウントされるコンテナのPATH / コンテナ内部のポートっていう理解がベスト
nocopy：volumeオプション。volume生成時のコンテナからデータのコピーを無効とするやつ。

他はunixソケットで使うものをマウントしている。

```
    environment:
      - DB_CONNECTION=mysql
      - DB_HOST=db
      - DB_PORT=3306
      - DB_DATABASE=${DB_NSME:-laravel_local}
      - DB_USERNAME=${DB_USER:-soregashi27}
      - DB_PASSWORD=${DB_PASS:-soregashidegozaru}
```
これは`.env`の内容を触ることなく動作をさせるために書いている。実際の開発で使う時は消しておいた方がいい。（面倒なら消さなくてもいい。）

```
      - DB_USERNAME=${DB_USER}
      - DB_PASSWORD=${DB_PASS}
```
こう書いても良さそう🤔

#### webコンテナ
```
  web:
    build:
      context: .
      dockerfile: ./infra/docker/nginx/Dockerfile
```
とりあえず、contextとdockerfileを埋めとけって話。


```
    ports:
      - target: 80
        published: ${ WEB_PORT:-80}
        protocol: tcp
        mode: host
    volumes:
      - type: bind
        source: php-fpm-socket
        target: /vat/run/php-fpm
        volume:
          nocopy: true
      - type: bind
        source: ./backend
```
php以外の静的コンテンツを返す。
`ports`を公開する。
nginxのデフォルトポート番号は80なのでそのまま設定。

・published: ${ WEB_PORT:-80}
公開ポート

・protocol: tcp
ポートプロトコル

・mode: host
`host`だと各ノード向けにホストポートを公開する。`ingress`はロードバランスを行うためのスウォームモードポート（？）
https://matsuand.github.io/docs.docker.jp.onthefly/compose/compose-file/compose-file-v3/



#### dbコンテナ
MySQLのデフォルトポート番号3306を使用
```
 ports:
      - target: 3306
        published: ${DB_PORT:-3306}
        protocol: tcp
        mode: host
    volumes:
      - type: volume
        source: db-store
        target: /var/lib/mysql
        volume:
          nocopy: true
    environment: 省略
```

内容は上記を参照

## 調べたこと 
下記参照

## 参考
Dockerfile記述のベストプラクティス
https://bit.ly/3uIKezs

docker-compose.ymlのbuild設定はとりあえずcontextもdockerfileも埋めとけって話
https://bit.ly/3gF8ASq

Dockerfileの書き方
https://bit.ly/3oICGcu

